### PR TITLE
Use progn combination for `prompter:object-attributes`

### DIFF
--- a/prompter-source.lisp
+++ b/prompter-source.lisp
@@ -339,6 +339,7 @@ See `actions-on-current-suggestion'."
 
 (export-always 'object-attributes)
 (defgeneric object-attributes (object source)
+  (:method-combination progn)
   (:method ((object t) (source prompter:source))
     (declare (ignorable source))
     (default-object-attributes object))
@@ -428,9 +429,14 @@ keys are the sentence-cased slot names and the values the slot values passed to
 
 It's used in `make-suggestion' which can be used as a `suggestion-maker' for `source's.
 
-It's useful to separate concerns and compose between different object attributes
-and different sources (for instance, the same `object-attributes' method can be
-inherited or used across different sources)."))
+It's useful to separate concerns and compose between different object
+attributes and different sources (for instance, the same
+`object-attributes' method can be inherited or used across different
+sources).
+
+Method combinations for `object-attributes' is `progn', so additional
+`progn'-qualified methods can help in composing attributes across
+specified classes."))
 
 (define-class suggestion ()
   ((value


### PR DESCRIPTION
It's our frequent use-case to compose `prompter:object-attributes` (as in [Nyxt hint-mode](https://github.com/atlas-engineer/nyxt/blob/75bf1a4448fd468cc9d6c18445065bcf44781e56/source/mode/hint.lisp#L319)). Which tends to be ugly and not-exactly-composable after all—adding :around methods everywhere is quite a crude was to do things.

`progn` method combination seems to be a better shot—`progn` methods are not limited in number, while being perfectly composable. The downsides exist, though:
- There are no `:before`/`:after` methods—only primary, `progn`, and `:around`. This doesn't exactly matter, because these barely matter for `prompter:object-attributes`—it's a pure function, after all.
- It requires more dispatching discipline, because dispatching over `prompter:source` might end up polluting lots of sources. But that's avoidable too—just use `progn` methods sparingly.

Mostly backwards-compatible too—I have no idea why anyone would use `:before`/`:after` methods in their prompts, so that shouldn't break anything.